### PR TITLE
Fixed TypeError if no device type is given in init

### DIFF
--- a/pystrom/device.py
+++ b/pystrom/device.py
@@ -42,7 +42,7 @@ class MyStromDevice():
         if self.device_type in self.DEVICE_TYPES:
             return self.DEVICE_TYPES[self.device_type]
         else:
-            return "Non-MyStrom-Device ("+self.device_type+")"
+            return f"Non-MyStrom-Device ({str(self.device_type)})"
 
 
     def __str__(self):


### PR DESCRIPTION
If no device type was given (or None), the init failed because of an error in the type_name property